### PR TITLE
Fix typo in getting-started.md

### DIFF
--- a/site/about/getting-started.md
+++ b/site/about/getting-started.md
@@ -9,7 +9,7 @@ doc: true
 
 Easy Rules is a Java library. It requires a Java 1.5+ runtime.
 
-## Building form source
+## Building from source
 
 To build Easy Rules from sources, you need to have [git](http://www.git-scm.com) and [maven](http://maven.apache.org/) installed and set up.
 


### PR DESCRIPTION
Changed "form" to "from" in the building from source header